### PR TITLE
Adding Databricks Access Connector

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -93,6 +93,17 @@ module "databricks_workspace" {
   tags                = local.tags
 }
 
+# Databricks Access Connector
+
+module "databricks_access_connector" {
+  source              = "./modules/databricks_access_connector"
+  prefix              = var.project
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  tags                = local.tags
+  storage_account_id  = module.lakehouse_storage.id
+}
+
 # Azure k8s Cluster
 
 module "aks" {

--- a/infrastructure/modules/databricks_access_connector/main.tf
+++ b/infrastructure/modules/databricks_access_connector/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    databricks = {
+      source  = "databricks/databricks"
+      version = "1.30.0"
+    }
+  }
+}
+
+resource "azurerm_databricks_access_connector" "databricks_connector" {
+  name                = "adb-access-connector-${var.prefix}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = var.tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_role_assignment" "access_connector_blob_contributor" {
+  principal_id         = azurerm_databricks_access_connector.databricks_connector.identity[0].principal_id
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = var.storage_account_id
+}

--- a/infrastructure/modules/databricks_access_connector/outputs.tf
+++ b/infrastructure/modules/databricks_access_connector/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = azurerm_databricks_access_connector.databricks_connector.identity[0].principal_id
+}

--- a/infrastructure/modules/databricks_access_connector/variables.tf
+++ b/infrastructure/modules/databricks_access_connector/variables.tf
@@ -1,0 +1,20 @@
+variable "prefix" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "storage_account_id" {
+  type        = string
+  description = "The resource ID of the Storage Account"
+}


### PR DESCRIPTION
# Adding Databricks Access Connector

## Description

This changes allows to deploy the Access Connector that will give access to Databricks to the lakehouse storage account